### PR TITLE
Fix code scanning alert no. 2: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/src/Application/src/RazorPagesTestSample/Pages/Index.cshtml.cs
+++ b/src/Application/src/RazorPagesTestSample/Pages/Index.cshtml.cs
@@ -94,12 +94,13 @@ namespace RazorPagesTestSample.Pages
 
         public static void WriteToDirectory(ZipArchiveEntry entry, string destDirectory)
         {
-            string destFileName = Path.Combine(destDirectory, entry.FullName);
+            string destFileName = Path.GetFullPath(Path.Combine(destDirectory, entry.FullName));
+            string fullDestDirPath = Path.GetFullPath(destDirectory + Path.DirectorySeparatorChar);
 
             // Ensure the destination file is within the destination directory
-            if (!Path.GetFullPath(destFileName).StartsWith(Path.GetFullPath(destDirectory), StringComparison.Ordinal))
+            if (!destFileName.StartsWith(fullDestDirPath, StringComparison.Ordinal))
             {
-            throw new InvalidOperationException("Entry is trying to write outside of the destination directory.");
+                throw new InvalidOperationException("Entry is trying to write outside of the destination directory.");
             }
 
             entry.ExtractToFile(destFileName);


### PR DESCRIPTION
Fixes [https://github.com/marcelloraffaele/TechExcel-Accelerate-developer-productivity-with-GitHub-Copilot-and-Dev-Box/security/code-scanning/2](https://github.com/marcelloraffaele/TechExcel-Accelerate-developer-productivity-with-GitHub-Copilot-and-Dev-Box/security/code-scanning/2)

To fix the problem, we need to ensure that the output paths constructed from zip archive entries are validated to prevent writing files to unexpected locations. This involves:
1. Using `Path.GetFullPath` to resolve any directory traversal elements in the combined path.
2. Ensuring the destination directory path ends with a directory separator character before resolving its full path.
3. Validating that the resolved output path starts with the resolved destination directory path.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
